### PR TITLE
Adding Support for G6

### DIFF
--- a/lib/messages/glucose-rx-message.js
+++ b/lib/messages/glucose-rx-message.js
@@ -1,9 +1,15 @@
 const crc = require('../crc');
 
-const opcode = 0x31;
+var opcode = 0x31;
 
-function GlucoseRxMessage(data) {
-  if ((data.length !== 16) || (data[0] !== opcode) || !crc.crcValid(data)) {
+function GlucoseRxMessage(data, id) {
+  f2 = id.substr(0,2);
+  // if serial number starts with 80xxxx or 81xxxx then assume g6 and use g6 GlucoseRx opcode = 0x4f
+  if (f2 == "80" || f2 == "81") {
+        opcode = 0x4f;
+  }
+
+  if ((data.length < 16) || (data[0] !== opcode) || !crc.crcValid(data)) {
     throw new Error('cannot create new GlucoseRxMessage');
   }
   this.status = data.readUInt8(1);

--- a/lib/messages/glucose-rx-message.js
+++ b/lib/messages/glucose-rx-message.js
@@ -1,12 +1,13 @@
 const crc = require('../crc');
 
-var opcode = 0x31;
+const g5_opcode = 0x31;
+const g6_opcode = 0x4f;
+let opcode = g5_opcode;
 
-function GlucoseRxMessage(data, id) {
-  f2 = id.substr(0,2);
-  // if serial number starts with 80xxxx or 81xxxx then assume g6 and use g6 GlucoseRx opcode = 0x4f
-  if (f2 == "80" || f2 == "81") {
-        opcode = 0x4f;
+function GlucoseRxMessage(data, g6_transmitter) {
+
+  if (g6_transmitter) {
+	opcode = g6_opcode;
   }
 
   if ((data.length < 16) || (data[0] !== opcode) || !crc.crcValid(data)) {

--- a/lib/messages/glucose-tx-message.js
+++ b/lib/messages/glucose-tx-message.js
@@ -1,14 +1,24 @@
 const crc = require('../crc');
 
-const opcode = 0x30;
+var opcode = 0x30;
 
-function GlucoseTxMessage() {
+function GlucoseTxMessage(id) {
+  f2 = id.substr(0,2);
+  // if serial number starts with 80xxxx or 81xxxx then assume g6 and use g6 GlucoseTx opcode = 0x4e
+  if (f2 == "80" || f2 == "81") {
+	opcode = 0x4e;
+  }
+
   this.data = Buffer.from([opcode]);
-
   const crcBuffer = Buffer.allocUnsafe(2);
   crcBuffer.writeUInt16LE(crc.crc16(this.data));
   this.data = Buffer.concat([this.data, crcBuffer]);
 }
+
+function firstTwoCharactersOfString(string) {
+  return string.substr(0,2);
+}
+
 
 GlucoseTxMessage.opcode = opcode;
 

--- a/lib/messages/glucose-tx-message.js
+++ b/lib/messages/glucose-tx-message.js
@@ -1,22 +1,19 @@
 const crc = require('../crc');
 
-var opcode = 0x30;
+const g5_opcode = 0x30;
+const g6_opcode = 0x4e;
+let opcode = g5_opcode;
 
-function GlucoseTxMessage(id) {
-  f2 = id.substr(0,2);
-  // if serial number starts with 80xxxx or 81xxxx then assume g6 and use g6 GlucoseTx opcode = 0x4e
-  if (f2 == "80" || f2 == "81") {
-	opcode = 0x4e;
+function GlucoseTxMessage(g6_transmitter) {
+
+  if (g6_transmitter) {
+	opcode = g6_opcode
   }
 
   this.data = Buffer.from([opcode]);
   const crcBuffer = Buffer.allocUnsafe(2);
   crcBuffer.writeUInt16LE(crc.crc16(this.data));
   this.data = Buffer.concat([this.data, crcBuffer]);
-}
-
-function firstTwoCharactersOfString(string) {
-  return string.substr(0,2);
 }
 
 

--- a/lib/messages/glucose-tx-message.js
+++ b/lib/messages/glucose-tx-message.js
@@ -7,7 +7,7 @@ let opcode = g5_opcode;
 function GlucoseTxMessage(g6_transmitter) {
 
   if (g6_transmitter) {
-	opcode = g6_opcode
+	opcode = g6_opcode;
   }
 
   this.data = Buffer.from([opcode]);

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -51,6 +51,14 @@ let _getMessages;
 
 function Transmitter(id, getMessages) {
   this.id = id;
+  this.g6_transmitter = false;
+
+  id_first2 = this.id.substr(0,2);
+  // if serial number starts with 80xxxx or 81xxxx then assume g6 
+  if (id_first2 == "80" || id_first2 == "81") {
+  	this.g6_transmitter = true;
+  }
+
   _getMessages = getMessages || (() => []);
   manager = new BluetoothManager(this);
 }
@@ -182,12 +190,12 @@ function control(messages) {
     return processMessages.call(this, messages, uuid, syncDate, timeMessage)
     // send glucose tx message
     .then(() => {
-      const message = new GlucoseTxMessage(this.id);
+      const message = new GlucoseTxMessage(this.g6_transmitter);
       return manager.writeValueAndWaitForNotification(message.data, uuid);
     })
     // on receipt of glucose rx message create new glucose and notify observers
     .then(data => {
-      const glucoseMessage = new GlucoseRxMessage(data, this.id);
+      const glucoseMessage = new GlucoseRxMessage(data, this.g6_transmitter);
       const message = new SensorTxMessage();
       return manager.writeValueAndWaitForNotification(message.data, uuid)
       .then((data) => {

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -28,7 +28,7 @@ const SessionStopTxMessage = require('./messages/session-stop-tx-message');     
 const SessionStopRxMessage = require('./messages/session-stop-rx-message');           // 0x29
 const SensorTxMessage = require('./messages/sensor-tx-message');                      // 0x2e
 const SensorRxMessage = require('./messages/sensor-rx-message');                      // 0x2f
-// Added support for g6 if serial number starts with 80xxxx or 81xxxx
+// Added support for g6 if serial number starts with 8xxxxx
 const GlucoseTxMessage = require('./messages/glucose-tx-message');                    // 0x30, 0x4e
 const GlucoseRxMessage = require('./messages/glucose-rx-message');                    // 0x31, 0x4f
 
@@ -53,9 +53,9 @@ function Transmitter(id, getMessages) {
   this.id = id;
   this.g6_transmitter = false;
 
-  id_first2 = this.id.substr(0,2);
-  // if serial number starts with 80xxxx or 81xxxx then assume g6 
-  if (id_first2 == "80" || id_first2 == "81") {
+  id_first = this.id.substr(0,1);
+  // if serial number starts with 8xxxxx then assume g6 
+  if (id_first == "8") {
   	this.g6_transmitter = true;
   }
 

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -32,7 +32,7 @@ const SensorRxMessage = require('./messages/sensor-rx-message');                
 const GlucoseTxMessage = require('./messages/glucose-tx-message');                    // 0x30, 0x4e
 const GlucoseRxMessage = require('./messages/glucose-rx-message');                    // 0x31, 0x4f
 
-const CalibrationDataTxMessage = require('./messages/calibration-data-tx-message');   // 0x32, 0x4f
+const CalibrationDataTxMessage = require('./messages/calibration-data-tx-message');   // 0x32
 const CalibrationDataRxMessage = require('./messages/calibration-data-rx-message');   // 0x33
 const CalibrateGlucoseTxMessage = require('./messages/calibrate-glucose-tx-message'); // 0x34
 const CalibrateGlucoseRxMessage = require('./messages/calibrate-glucose-rx-message'); // 0x35

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -28,9 +28,11 @@ const SessionStopTxMessage = require('./messages/session-stop-tx-message');     
 const SessionStopRxMessage = require('./messages/session-stop-rx-message');           // 0x29
 const SensorTxMessage = require('./messages/sensor-tx-message');                      // 0x2e
 const SensorRxMessage = require('./messages/sensor-rx-message');                      // 0x2f
-const GlucoseTxMessage = require('./messages/glucose-tx-message');                    // 0x30
-const GlucoseRxMessage = require('./messages/glucose-rx-message');                    // 0x31
-const CalibrationDataTxMessage = require('./messages/calibration-data-tx-message');   // 0x32
+// Added support for g6 if serial number starts with 80xxxx or 81xxxx
+const GlucoseTxMessage = require('./messages/glucose-tx-message');                    // 0x30, 0x4e
+const GlucoseRxMessage = require('./messages/glucose-rx-message');                    // 0x31, 0x4f
+
+const CalibrationDataTxMessage = require('./messages/calibration-data-tx-message');   // 0x32, 0x4f
 const CalibrationDataRxMessage = require('./messages/calibration-data-rx-message');   // 0x33
 const CalibrateGlucoseTxMessage = require('./messages/calibrate-glucose-tx-message'); // 0x34
 const CalibrateGlucoseRxMessage = require('./messages/calibrate-glucose-rx-message'); // 0x35
@@ -180,12 +182,12 @@ function control(messages) {
     return processMessages.call(this, messages, uuid, syncDate, timeMessage)
     // send glucose tx message
     .then(() => {
-      const message = new GlucoseTxMessage();
+      const message = new GlucoseTxMessage(this.id);
       return manager.writeValueAndWaitForNotification(message.data, uuid);
     })
     // on receipt of glucose rx message create new glucose and notify observers
     .then(data => {
-      const glucoseMessage = new GlucoseRxMessage(data);
+      const glucoseMessage = new GlucoseRxMessage(data, this.id);
       const message = new SensorTxMessage();
       return manager.writeValueAndWaitForNotification(message.data, uuid)
       .then((data) => {


### PR DESCRIPTION
Adds support for G6 based on xdrip+ changes. I have only tested compatibility remains with the g5 and can't test a g6 until somebody gets one and tries it out. These changes assume that a g6 serial number starts with 80xxxx or 81xxxx.

