### PR TITLE
Send saw transmitter message

### DIFF
--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -71,7 +71,7 @@ Transmitter.prototype.shouldConnect = function(peripheral) {
      return false;
    } else if (lastTwoCharactersOfString(name) == lastTwoCharactersOfString(this.id)) {
      this.rssi = peripheral.rssi;
-     this.emit('sawTransmitter', { rssi: peripheral.rssi });
+     this.emit('sawTransmitter', { id: this.id, rssi: peripheral.rssi });
      return true;
    }
 

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -69,10 +69,13 @@ Transmitter.prototype.shouldConnect = function(peripheral) {
   const name = peripheral.advertisement.localName;
    if (!name){
      return false;
-   } else {
+   } else if (lastTwoCharactersOfString(name) == lastTwoCharactersOfString(this.id)) {
      this.rssi = peripheral.rssi;
-     return lastTwoCharactersOfString(name) == lastTwoCharactersOfString(this.id);
+     this.emit('sawTransmitter', { rssi: peripheral.rssi });
+     return true;
    }
+
+   return false;
 };
 
 Transmitter.prototype.isReady = function() {
@@ -286,7 +289,7 @@ function processMessages(messages, uuid, syncDate, timeMessage) {
           console.log("got BatteryStatus Rx");
         }
       this.emit('messageProcessed', {time: message.date});
-      console.log("got message " + rxMessage);
+      console.log("got message:\n", rxMessage);
     });
   }
   return promise;


### PR DESCRIPTION
Send a saw transmitter message when the transmitter we are looking for successfully connects.

This will provide visibility to the higher level application to recognize when the transmitter is connecting, but not successfully completing the glucose read.