### PR TITLE
adding g6 scaling multiplier for raw (unfiltered / filtered) values

### DIFF
--- a/lib/messages/sensor-rx-message.js
+++ b/lib/messages/sensor-rx-message.js
@@ -1,8 +1,9 @@
 const crc = require('../crc');
 
 const opcode = 0x2f;
+const g6_scale = 32;
 
-function SensorRxMessage(data) {
+function SensorRxMessage(data, g6_transmitter) {
   if ((data.length !== 16) || (data[0] !== opcode) || !crc.crcValid(data)) {
     throw new Error('cannot create new SensorRxMessage');
   }
@@ -10,6 +11,10 @@ function SensorRxMessage(data) {
   this.timestamp = data.readUInt32LE(2);
   this.unfiltered = data.readUInt32LE(6);
   this.filtered = data.readUInt32LE(10);
+  if (g6_transmitter) {
+    this.unfiltered *= g6_scale;
+    this.filtered *= g6_scale;
+  }
 }
 
 SensorRxMessage.opcode = opcode;

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -199,7 +199,7 @@ function control(messages) {
       const message = new SensorTxMessage();
       return manager.writeValueAndWaitForNotification(message.data, uuid)
       .then((data) => {
-        const message = new SensorRxMessage(data);
+        const message = new SensorRxMessage(data, this.g6_transmitter);
         const glucose = new Glucose(glucoseMessage, timeMessage, syncDate, sensorMessage = message);
         glucose.rssi = this.rssi;
         this.emit('glucose', glucose);


### PR DESCRIPTION
The g6 raw data values require a multiplication factor to be equivalent to the same ranges used with the g5. The scaling factor is 32 and is applied within the sensor rx message processing.