### PR TITLE
fix for setting sensor code on g6 session start

### DIFF
--- a/lib/messages/g6/session-start-tx-message.js
+++ b/lib/messages/g6/session-start-tx-message.js
@@ -12,8 +12,8 @@ function SessionStartTxMessage(startTime, sensorSerialCode) {
 
   if (!this.params.isNullCode() && this.params.isValid()) {
     const codeBuffer = Buffer.allocUnsafe(4);
-    codeBuffer.writeUInt16LE(this.data.params.paramA);
-    codeBuffer.writeUInt16LE(this.data.params.paramB, 2);
+    codeBuffer.writeUInt16LE(this.params.paramA);
+    codeBuffer.writeUInt16LE(this.params.paramB, 2);
     this.data = Buffer.concat([this.data, codeBuffer]);
   }
 

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -350,6 +350,8 @@ module.exports = class Transmitter extends EventEmitter {
           // TODO: notify command source that the operation has completed
         } catch (error) {
           // TODO: notify the command source of the error
+          debug(`Error sending command: ${message.type}`);
+          debug(error);
         }
       }
 


### PR DESCRIPTION
Fixes the following error sending start session msg when using sensor code for g6:

TypeError: Cannot read property 'paramA' of undefined