### PR TITLE
Update noble

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "crc": "^3.4.4",
     "debug": "^4.1.0",
-    "noble": "thebookins/noble",
+    "noble": "xdrip-js/noble",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Noble depended on bluetooth-hci-socket that was no longer maintained by it's original maintainer and did not support node 10.

The noble update drops support for very old node versions and changes the reference to bluetooth-socket-hci-socket to a community maintained version that supports node 10.